### PR TITLE
Release 0.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,14 @@ requirements:
     - npctypes
 
 test:
+  source_files:
+    - tests
+
   imports:
     - mplview
+
+  commands:
+    - python -m unittest discover -s .
 
 about:
   home: https://github.com/jakirkham/mplview

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "mplview" %}
-{% set version = "0.0.1" %}
-{% set sha256 = "06a6cbe922f2a0d95938dcb2937b0b8fbdabd0c81b2f2ee58ee70fc616776e3b" %}
+{% set version = "0.0.2" %}
+{% set sha256 = "03304db8fbdd70da1bcef91d3835fa1796a6cd61d9c03a3be578bdf0634b1ed7" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
```markdown
### v0.0.2

* Extend license copyright into 2017. #5
* Recut with cookiecutter. #6
* Update copyright years in docs. #7
* Ignore eggs when measuring coverage. #8
* Require `mock` for CI. #9
* Fix intensity scale selection bug. #10
* Add unit tests. #4
* Drop mock from test requirements. #15
```